### PR TITLE
Mark nodelete during linking to work around unload bug in upstream LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 \
 -Wextra -Wall -Winvalid-pch -Wredundant-decls -Wformat=2 \
 -Wmissing-format-attribute -Wformat-nonliteral -Werror")
 
+# Mark nodelete to work around unload bug in upstream LLVM 5.0+
+set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-z,nodelete")
+
 # This is the compiler pass that we later load into clang or opt. If LLVM is
 # built without RTTI we have to disable it for our library too, otherwise we'll
 # get linker errors.


### PR DESCRIPTION
clang would segfault when running symcc with LLVM 8.0 built from upstream. This is a well-known issue, affecting AFL, etc. (see [here](https://github.com/google/AFL/blob/master/llvm_mode/Makefile#L40)).

I applied the same fix that AFL uses and the segfault disappeared.