### PR TITLE
Added fopen64 wrapper

### DIFF
--- a/compiler/Runtime.cpp
+++ b/compiler/Runtime.cpp
@@ -158,9 +158,9 @@ Runtime::Runtime(Module &M) {
 /// Decide whether a function is called symbolically.
 bool isInterceptedFunction(const Function &f) {
   static const StringSet<> kInterceptedFunctions = {
-      "malloc",  "calloc",  "mmap",   "mmap64", "open",   "read",   "lseek",
-      "lseek64", "fopen",   "fread",  "fseek",  "getc",   "ungetc", "memcpy",
-      "memset",  "strncpy", "strchr", "memcmp", "memmove"};
+      "malloc",  "calloc",  "mmap",    "mmap64", "open",   "read",   "lseek",
+      "lseek64", "fopen",   "fopen64", "fread",  "fseek",  "getc",   "ungetc",
+      "memcpy",  "memset",  "strncpy", "strchr", "memcmp", "memmove"};
 
   return (kInterceptedFunctions.count(f.getName()) > 0);
 }

--- a/runtime/LibcWrappers.cpp
+++ b/runtime/LibcWrappers.cpp
@@ -206,6 +206,24 @@ FILE *SYM(fopen)(const char *pathname, const char *mode) {
   return result;
 }
 
+FILE *SYM(fopen64)(const char *pathname, const char *mode) {
+  auto *result = fopen64(pathname, mode);
+  _sym_set_return_expression(nullptr);
+
+  if (result != nullptr && !g_config.fullyConcrete &&
+      !g_config.inputFile.empty() &&
+      strstr(pathname, g_config.inputFile.c_str()) != nullptr) {
+    if (inputFileDescriptor != -1)
+      std::cerr << "Warning: input file opened multiple times; this is not yet "
+                   "supported"
+                << std::endl;
+    inputFileDescriptor = fileno(result);
+    inputOffset = 0;
+  }
+
+  return result;
+}
+
 size_t SYM(fread)(void *ptr, size_t size, size_t nmemb, FILE *stream) {
   tryAlternative(ptr, _sym_get_parameter_expression(0), SYM(fread));
   tryAlternative(size, _sym_get_parameter_expression(1), SYM(fread));


### PR DESCRIPTION
One of the targets that I tried symcc against compiled `fopen` into `fopen64`, which was not wrapped appropriately by the symcc compiler.

Therefore, I've added a `fopen64` wrapper.