### PR TITLE
strchr fix

### DIFF
--- a/runtime/LibcWrappers.cpp
+++ b/runtime/LibcWrappers.cpp
@@ -343,7 +343,7 @@ const char *SYM(strchr)(const char *s, int c) {
     return result;
 
   if (cExpr == nullptr)
-    cExpr = _sym_build_integer(c, 8);
+    cExpr = _sym_build_integer(c, 32);
 
   size_t length = result != nullptr ? (result - s) : strlen(s);
   auto shadow = ReadOnlyShadow(s, length);
@@ -351,7 +351,7 @@ const char *SYM(strchr)(const char *s, int c) {
   for (size_t i = 0; i < length; i++) {
     _sym_push_path_constraint(
         _sym_build_not_equal(
-            (*shadowIt != nullptr) ? *shadowIt : _sym_build_integer(s[i], 8),
+            (*shadowIt != nullptr) ? *shadowIt : _sym_build_integer(s[i], 32),
             cExpr),
         /*taken*/ 1, reinterpret_cast<uintptr_t>(SYM(strchr)));
     ++shadowIt;

--- a/runtime/LibcWrappers.cpp
+++ b/runtime/LibcWrappers.cpp
@@ -343,7 +343,9 @@ const char *SYM(strchr)(const char *s, int c) {
     return result;
 
   if (cExpr == nullptr)
-    cExpr = _sym_build_integer(c, 32);
+    cExpr = _sym_build_integer(c, 8);
+  else
+    cExpr = _sym_build_trunc(cExpr, 8);
 
   size_t length = result != nullptr ? (result - s) : strlen(s);
   auto shadow = ReadOnlyShadow(s, length);
@@ -351,7 +353,7 @@ const char *SYM(strchr)(const char *s, int c) {
   for (size_t i = 0; i < length; i++) {
     _sym_push_path_constraint(
         _sym_build_not_equal(
-            (*shadowIt != nullptr) ? *shadowIt : _sym_build_integer(s[i], 32),
+            (*shadowIt != nullptr) ? *shadowIt : _sym_build_integer(s[i], 8),
             cExpr),
         /*taken*/ 1, reinterpret_cast<uintptr_t>(SYM(strchr)));
     ++shadowIt;

--- a/runtime/Shadow.h
+++ b/runtime/Shadow.h
@@ -16,6 +16,7 @@
 #define SHADOW_H
 
 #include <algorithm>
+#include <cassert>
 #include <cstring>
 #include <iterator>
 #include <map>
@@ -33,6 +34,9 @@
 // provides iterators over shadow memory that automatically handle jumps between
 // memory pages (and thus shadow regions). They should work with the C++
 // standard library.
+//
+// We represent shadowed memory as a sequence of 8-bit expressions. The
+// iterators therefore expose the shadow in the form of byte expressions.
 //
 
 constexpr uintptr_t kPageSize = 4096;
@@ -79,7 +83,12 @@ public:
     return *this;
   }
 
-  SymExpr operator*() { return shadow_ != nullptr ? *shadow_ : nullptr; }
+  SymExpr operator*() {
+    assert((shadow_ == nullptr || *shadow_ == nullptr ||
+            _sym_bits_helper(*shadow_) == 8) &&
+           "Shadow memory always represents bytes");
+    return shadow_ != nullptr ? *shadow_ : nullptr;
+  }
 
   bool operator==(const ReadShadowIterator &other) const {
     return (address_ == other.address_);

--- a/runtime/simple_backend/Runtime.cpp
+++ b/runtime/simple_backend/Runtime.cpp
@@ -22,7 +22,7 @@
 #include <set>
 #include <vector>
 
-#ifdef DEBUG_RUNTIME
+#ifndef NDEBUG
 #include <chrono>
 #endif
 
@@ -31,7 +31,7 @@
 #include "LibcWrappers.h"
 #include "Shadow.h"
 
-#ifdef DEBUG_RUNTIME
+#ifndef NDEBUG
 // Helper to print pointers properly.
 #define P(ptr) reinterpret_cast<void *>(ptr)
 #endif
@@ -62,7 +62,7 @@ Z3_solver g_solver; // TODO make thread-local
 // Some global constants for efficiency.
 Z3_ast g_null_pointer, g_true, g_false;
 
-#ifdef DEBUG_RUNTIME
+#ifndef NDEBUG
 [[maybe_unused]] void dump_known_regions() {
   std::cout << "Known regions:" << std::endl;
   for (const auto &[page, shadow] : g_shadow_pages) {
@@ -107,7 +107,7 @@ void _sym_initialize(void) {
   if (g_initialized.test_and_set())
     return;
 
-#ifdef DEBUG_RUNTIME
+#ifndef NDEBUG
   std::cout << "Initializing symbolic runtime" << std::endl;
 #endif
 
@@ -122,7 +122,7 @@ void _sym_initialize(void) {
   g_context = Z3_mk_context_rc(cfg);
   Z3_del_config(cfg);
 
-#ifdef DEBUG_RUNTIME
+#ifndef NDEBUG
   Z3_set_error_handler(g_context, handle_z3_error);
 #endif
 
@@ -502,7 +502,7 @@ void _sym_collect_garbage() {
   if (allocatedExpressions.size() < g_config.garbageCollectionThreshold)
     return;
 
-#ifdef DEBUG_RUNTIME
+#ifndef NDEBUG
   auto start = std::chrono::high_resolution_clock::now();
   auto startSize = allocatedExpressions.size();
 #endif
@@ -517,7 +517,7 @@ void _sym_collect_garbage() {
     }
   }
 
-#ifdef DEBUG_RUNTIME
+#ifndef NDEBUG
   auto end = std::chrono::high_resolution_clock::now();
   auto endSize = allocatedExpressions.size();
 


### PR DESCRIPTION
The second argument to strchr is an int, not a char. The original strchr wrapper was causing "incompatible sort" error messages in z3 because the LHS of the expression was 8 bits and the RHS was 32 bits when calling `_sym_get_parameter_expression`.

Now all types are the same, however I'm not 100% sure on the fix and what other affects this may have on the shadow memory. Nevertheless, the "incompatible sort" error has disappeared. 