### PR TITLE
Optionally log runtime information to a file

### DIFF
--- a/runtime/Config.cpp
+++ b/runtime/Config.cpp
@@ -53,6 +53,10 @@ void loadConfig() {
   if (inputFile != nullptr)
     g_config.inputFile = inputFile;
 
+  auto *logFile = getenv("SYMCC_LOG_FILE");
+  if (logFile != nullptr)
+    g_config.logFile = logFile;
+
   auto *pruning = getenv("SYMCC_ENABLE_LINEARIZATION");
   if (pruning != nullptr)
     g_config.pruning = checkFlagString(pruning);

--- a/runtime/Config.h
+++ b/runtime/Config.h
@@ -27,6 +27,9 @@ struct Config {
   /// The input file, if any.
   std::string inputFile;
 
+  /// The file to log constraint solving information to.
+  std::string logFile = "";
+
   /// Do we prune expressions on hot paths?
   bool pruning = false;
 


### PR DESCRIPTION
Not sure how useful this is in a broader context, but I found it useful to separate symcc output from the target program output.