### PR TITLE
Make tests endianness-agnostic

### DIFF
--- a/compiler/Runtime.cpp
+++ b/compiler/Runtime.cpp
@@ -160,7 +160,7 @@ bool isInterceptedFunction(const Function &f) {
   static const StringSet<> kInterceptedFunctions = {
       "malloc",  "calloc",  "mmap",    "mmap64", "open",   "read",   "lseek",
       "lseek64", "fopen",   "fopen64", "fread",  "fseek",  "getc",   "ungetc",
-      "memcpy",  "memset",  "strncpy", "strchr", "memcmp", "memmove"};
+      "memcpy",  "memset",  "strncpy", "strchr", "memcmp", "memmove", "ntohl"};
 
   return (kInterceptedFunctions.count(f.getName()) > 0);
 }

--- a/runtime/LibcWrappers.cpp
+++ b/runtime/LibcWrappers.cpp
@@ -413,13 +413,12 @@ int SYM(memcmp)(const void *a, const void *b, size_t n) {
 uint32_t SYM(ntohl)(uint32_t netlong)
 {
   auto netlongExpr = _sym_get_parameter_expression(0);
-  tryAlternative(netlong, netlongExpr, SYM(ntohl));
-
   auto result = ntohl(netlong);
-  _sym_set_return_expression(nullptr);
 
-  if (netlongExpr->isConcrete())
+  if (netlongExpr == nullptr) {
+    _sym_set_return_expression(nullptr);
     return result;
+  }
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   _sym_set_return_expression(_sym_build_bswap(netlongExpr));

--- a/test/bswap.c
+++ b/test/bswap.c
@@ -40,10 +40,10 @@ int main(int argc, char* argv[]) {
 
   // SIMPLE: Trying to solve
   // SIMPLE: Found diverging input
-  // SIMPLE-DAG: stdin0 -> #xca
-  // SIMPLE-DAG: stdin1 -> #xfe
-  // SIMPLE-DAG: stdin2 -> #xbe
-  // SIMPLE-DAG: stdin3 -> #xef
+  // SIMPLE-DAG: stdin0 -> #xef
+  // SIMPLE-DAG: stdin1 -> #xbe
+  // SIMPLE-DAG: stdin2 -> #xfe
+  // SIMPLE-DAG: stdin3 -> #xca
   // QSYM-COUNT-2: SMT
   // ANY: Not quite.
   if (y == 0xcafebeef)

--- a/test/bswap.c
+++ b/test/bswap.c
@@ -13,12 +13,15 @@
 // SymCC. If not, see <https://www.gnu.org/licenses/>.
 
 // RUN: %symcc %s -o %t
-// RUN: echo -ne "\x01\x02\x03\x04" | %t 2>&1 | %filecheck %s
+// RUN: echo -ne "\x04\x03\x02\x01" | %t 2>&1 | %filecheck %s
 // RUN: %symcc %s -S -emit-llvm -o - | FileCheck --check-prefix=BITCODE %s
 //
 // Here we test that the "bswap" intrinsic is handled correctly.
+
 #include <stdint.h>
 #include <stdio.h>
+
+#include <arpa/inet.h>
 #include <unistd.h>
 
 int main(int argc, char* argv[]) {
@@ -27,6 +30,7 @@ int main(int argc, char* argv[]) {
     fprintf(stderr, "Failed to read x\n");
     return -1;
   }
+  x = ntohl(x);
 
   // BITCODE: llvm.bswap.i32
   uint32_t y = __builtin_bswap32(x);

--- a/test/bswap.test32
+++ b/test/bswap.test32
@@ -1,3 +1,3 @@
 RUN: %symcc -m32 %S/bswap.c -o %t_32
-RUN: echo -ne "\x01\x02\x03\x04" | %t_32 2>&1 | %filecheck %S/bswap.c
+RUN: echo -ne "\x04\x03\x02\x01" | %t_32 2>&1 | %filecheck %S/bswap.c
 RUN: %symcc %S/bswap.c -m32 -S -emit-llvm -o - | FileCheck --check-prefix=BITCODE %S/bswap.c

--- a/test/file_input.c
+++ b/test/file_input.c
@@ -12,12 +12,14 @@
 // You should have received a copy of the GNU General Public License along with
 // SymCC. If not, see <https://www.gnu.org/licenses/>.
 
-// RUN: /bin/echo -ne "\x05\x00\x00\x00aaaa" > %T/%basename_t.input
+// RUN: /bin/echo -ne "\x00\x00\x00\x05aaaa" > %T/%basename_t.input
 // RUN: %symcc -O2 %s -o %t
 // RUN: env SYMCC_INPUT_FILE=%T/%basename_t.input %t %T/%basename_t.input 2>&1 | %filecheck %s
 
-#include <fcntl.h>
 #include <stdio.h>
+
+#include <arpa/inet.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -38,6 +40,7 @@ int main(int argc, char* argv[]) {
     perror("failed to read from the input file");
     return -1;
   }
+  input = ntohl(input);
 
   int four_as;
   if (read(fd, &four_as, sizeof(four_as)) != 4) {
@@ -110,6 +113,7 @@ int main(int argc, char* argv[]) {
     perror("failed to read from the input file");
     return -1;
   }
+  same_input = ntohl(same_input);
 
   // SIMPLE: Trying to solve
   // QSYM-COUNT-2: SMT

--- a/test/file_input.test32
+++ b/test/file_input.test32
@@ -1,3 +1,3 @@
-RUN: /bin/echo -ne "\x05\x00\x00\x00aaaa" > %T/%basename_t.input
+RUN: /bin/echo -ne "\x00\x00\x00\x05aaaa" > %T/%basename_t.input
 RUN: %symcc -m32 -O2 %S/file_input.c -o %t_32
 RUN: env SYMCC_INPUT_FILE=%T/%basename_t.input %t_32 %T/%basename_t.input 2>&1 | %filecheck %S/file_input.c

--- a/test/floats.c
+++ b/test/floats.c
@@ -13,9 +13,12 @@
 // SymCC. If not, see <https://www.gnu.org/licenses/>.
 
 // RUN: %symcc -O2 %s -o %t
-// RUN: echo -ne "\x05\x00\x00\x00" | %t 2>&1 | %filecheck %s
+// RUN: echo -ne "\x00\x00\x00\x05" | %t 2>&1 | %filecheck %s
+
 #include <stdint.h>
 #include <stdio.h>
+
+#include <arpa/inet.h>
 #include <unistd.h>
 
 float g_value = 0.1234;
@@ -26,6 +29,7 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "Failed to read x\n");
     return -1;
   }
+  x = ntohl(x);
 
   g_value += x;
   fprintf(stderr, "%f\n", g_value);

--- a/test/floats.test32
+++ b/test/floats.test32
@@ -1,2 +1,2 @@
 RUN: %symcc -m32 -O2 %S/floats.c -o %t_32
-RUN: echo -ne "\x05\x00\x00\x00" | %t_32 2>&1 | %filecheck %S/floats.c
+RUN: echo -ne "\x00\x00\x00\x05" | %t_32 2>&1 | %filecheck %S/floats.c

--- a/test/globals.c
+++ b/test/globals.c
@@ -13,13 +13,16 @@
 // SymCC. If not, see <https://www.gnu.org/licenses/>.
 
 // RUN: %symcc -O2 %s -o %t
-// RUN: echo -ne "\x05\x00\x00\x00" | %t 2>&1 | %filecheck %s
+// RUN: echo -ne "\x00\x00\x00\x05" | %t 2>&1 | %filecheck %s
 //
 // Test that global variables are handled correctly. The special challenge is
 // that we need to initialize the symbolic expression corresponding to any
 // global variable that has an initial value.
-#include <stdio.h>
+
 #include <stdint.h>
+#include <stdio.h>
+
+#include <arpa/inet.h>
 #include <unistd.h>
 
 int g_increment = 17;
@@ -61,6 +64,7 @@ int main(int argc, char* argv[]) {
         fprintf(stderr, "Failed to read x\n");
         return -1;
     }
+    x = ntohl(x);
 
     fprintf(stderr, "%d\n", increment(x));
     // SIMPLE: Trying to solve

--- a/test/globals.test32
+++ b/test/globals.test32
@@ -1,2 +1,2 @@
 RUN: %symcc -m32 -O2 %S/globals.c -o %t_32
-RUN: echo -ne "\x05\x00\x00\x00" | %t_32 2>&1 | %filecheck %S/globals.c
+RUN: echo -ne "\x00\x00\x00\x05" | %t_32 2>&1 | %filecheck %S/globals.c

--- a/test/large_alloc.test32
+++ b/test/large_alloc.test32
@@ -1,2 +1,2 @@
 RUN: %symcc -m32 %S/large_alloc.c -o %t_32
-RUN: echo -ne "\x2a\x00\x00\x00" | %t_32 2>&1 | %filecheck %S/large_alloc.c
+RUN: echo -ne "\x00\x00\x00\x2a" | %t_32 2>&1 | %filecheck %S/large_alloc.c

--- a/test/loop.c
+++ b/test/loop.c
@@ -13,12 +13,15 @@
 // SymCC. If not, see <https://www.gnu.org/licenses/>.
 
 // RUN: %symcc -O2 %s -o %t
-// RUN: echo -ne "\x05\x00\x00\x00" | %t 2>&1 | %filecheck %s
+// RUN: echo -ne "\x00\x00\x00\x05" | %t 2>&1 | %filecheck %s
 //
 // Make sure that our instrumentation works with back-jumps. Also, test support
 // for 128-bit integers (if available).
-#include <stdio.h>
+
 #include <stdint.h>
+#include <stdio.h>
+
+#include <arpa/inet.h>
 #include <unistd.h>
 
 #ifdef __SIZEOF_INT128__
@@ -45,6 +48,7 @@ int main(int argc, char* argv[]) {
         fprintf(stderr, "Failed to read x\n");
         return -1;
     }
+    x = ntohl(x);
     fprintf(stderr, "%d\n", fac(x));
     return 0;
 }

--- a/test/loop.test32
+++ b/test/loop.test32
@@ -1,2 +1,2 @@
 RUN: %symcc -m32 -O2 %S/loop.c -o %t_32
-RUN: echo -ne "\x05\x00\x00\x00" | %t_32 2>&1 | %filecheck %S/loop.c
+RUN: echo -ne "\x00\x00\x00\x05" | %t_32 2>&1 | %filecheck %S/loop.c

--- a/test/memcpy.c
+++ b/test/memcpy.c
@@ -13,14 +13,17 @@
 // SymCC. If not, see <https://www.gnu.org/licenses/>.
 
 // RUN: %symcc -O2 %s -o %t
-// RUN: echo -ne "\x00\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00" | %t 2>&1 | %filecheck %s
+// RUN: echo -ne "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x03" | %t 2>&1 | %filecheck %s
 //
 // Test that we generate alternative inputs for the parameters to memcpy (which
 // should assert that the concept works for other functions as well). Also, make
 // sure that we handle the different parameter sizes for mmap correctly.
+
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+
+#include <arpa/inet.h>
 #include <sys/mman.h>
 #include <unistd.h>
 
@@ -34,17 +37,20 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "Failed to read dest_offset\n");
     return -1;
   }
+  dest_offset = ntohl(dest_offset);
   int src_offset;
   if (read(STDIN_FILENO, &src_offset, sizeof(src_offset)) !=
       sizeof(src_offset)) {
     fprintf(stderr, "Failed to read src_offset\n");
     return -1;
   }
+  src_offset = ntohl(src_offset);
   int length;
   if (read(STDIN_FILENO, &length, sizeof(length)) != sizeof(length)) {
     fprintf(stderr, "Failed to read length\n");
     return -1;
   }
+  length = ntohl(length);
 
   memcpy(values_copy + dest_offset, values + src_offset, length);
   fprintf(stderr, "%d\n", values_copy[0]);

--- a/test/memcpy.test32
+++ b/test/memcpy.test32
@@ -1,2 +1,2 @@
 RUN: %symcc -m32 -O2 %S/memcpy.c -o %t_32
-RUN: echo -ne "\x00\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00" | %t_32 2>&1 | %filecheck %S/memcpy.c
+RUN: echo -ne "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x03" | %t_32 2>&1 | %filecheck %S/memcpy.c

--- a/test/pointers.c
+++ b/test/pointers.c
@@ -13,12 +13,15 @@
 // SymCC. If not, see <https://www.gnu.org/licenses/>.
 
 // RUN: %symcc -O2 %s -o %t
-// RUN: echo -ne "\x05\x00\x00\x00\x12\x34\x56\x78\x90\xab\xcd\xef" | %t 2>&1 | %filecheck %s
-#include <stdio.h>
+// RUN: echo -ne "\x00\x00\x00\x05\x12\x34\x56\x78\x90\xab\xcd\xef" | %t 2>&1 | %filecheck %s
+
 #include <stdint.h>
+#include <stdio.h>
+
+#include <arpa/inet.h>
 #include <unistd.h>
 
-volatile int g_value = 0x00ab0012;
+volatile int g_value;
 
 int main(int argc, char* argv[]) {
     int x;
@@ -27,10 +30,12 @@ int main(int argc, char* argv[]) {
         fprintf(stderr, "Failed to read x\n");
         return -1;
     }
+    x = ntohl(x);
     if (read(STDIN_FILENO, &ptr, sizeof(ptr)) != sizeof(ptr)) {
         fprintf(stderr, "Failed to read ptr\n");
         return -1;
     }
+    g_value = htonl(0x1200ab00);
     uint8_t *charPtr = (uint8_t*)&g_value;
 
     charPtr += 2;

--- a/test/pointers.c
+++ b/test/pointers.c
@@ -68,9 +68,9 @@ int main(int argc, char* argv[]) {
     // We expect a null pointer, but since pointer length varies between 32 and
     // 64-bit architectures we can't just expect N times #x00. Instead, we use a
     // regular expression that disallows nonzero values for anything but stdin0
-    // (which is part of x, not ptr).
+    // to stdin3 (which are part of x, not ptr).
     //
-    // SIMPLE-NOT: stdin{{[^0][0-9]?}} -> #x{{.?[^0].?}}
+    // SIMPLE-NOT: stdin{{[4-9]|1[0-9]}} -> #x{{.?[^0].?}}
     // QSYM-COUNT-2: SMT
     // QSYM: New testcase
     // ANY: not null

--- a/test/pointers.test32
+++ b/test/pointers.test32
@@ -1,2 +1,2 @@
 RUN: %symcc -m32 -O2 %S/pointers.c -o %t_32
-RUN: echo -ne "\x05\x00\x00\x00\x12\x34\x56\x78" | %t_32 2>&1 | %filecheck %S/pointers.c
+RUN: echo -ne "\x00\x00\x00\x05\x12\x34\x56\x78" | %t_32 2>&1 | %filecheck %S/pointers.c

--- a/test/structs.c
+++ b/test/structs.c
@@ -13,9 +13,12 @@
 // SymCC. If not, see <https://www.gnu.org/licenses/>.
 
 // RUN: %symcc -O2 %s -o %t
-// RUN: echo -ne "\x05\x00\x00\x00" | %t 2>&1 | %filecheck %s
-#include <stdio.h>
+// RUN: echo -ne "\x00\x00\x00\x05" | %t 2>&1 | %filecheck %s
+
 #include <stdint.h>
+#include <stdio.h>
+
+#include <arpa/inet.h>
 #include <unistd.h>
 
 struct point {
@@ -37,6 +40,7 @@ int main(int argc, char* argv[]) {
         fprintf(stderr, "Failed to read x\n");
         return -1;
     }
+    x = ntohl(x);
 
     struct point p = {x, 17};
 

--- a/test/structs.test32
+++ b/test/structs.test32
@@ -1,2 +1,2 @@
 RUN: %symcc -m32 -O2 %S/structs.c -o %t_32
-RUN: echo -ne "\x05\x00\x00\x00" | %t_32 2>&1 | %filecheck %S/structs.c
+RUN: echo -ne "\x00\x00\x00\x05" | %t_32 2>&1 | %filecheck %S/structs.c

--- a/test/switch.c
+++ b/test/switch.c
@@ -13,12 +13,14 @@
 // SymCC. If not, see <https://www.gnu.org/licenses/>.
 
 // RUN: %symcc -O2 %s -o %t
-// RUN: echo -ne "\x05\x00\x00\x00" | %t 2>&1 | %filecheck %s
+// RUN: echo -ne "\x00\x00\x00\x05" | %t 2>&1 | %filecheck %s
 //
 // Check the symbolic handling of "read"
 
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
+
+#include <arpa/inet.h>
 #include <unistd.h>
 
 int main(int argc, char* argv[]) {
@@ -27,6 +29,7 @@ int main(int argc, char* argv[]) {
     fprintf(stderr, "Failed to read x\n");
     return -1;
   }
+  x = ntohl(x);
 
   int foo = 0;
   switch (x) {

--- a/test/switch.test32
+++ b/test/switch.test32
@@ -1,2 +1,2 @@
 RUN: %symcc -m32 -O2 %S/switch.c -o %t_32
-RUN: echo -ne "\x05\x00\x00\x00" | %t_32 2>&1 | %filecheck %S/switch.c
+RUN: echo -ne "\x00\x00\x00\x05" | %t_32 2>&1 | %filecheck %S/switch.c


### PR DESCRIPTION
Currently tests take binary input in little-endian format and thus fail
on big-endian systems.

Fix by converting inputs to network byte order, using ntohl() in tests
and providing the symbolic ntohl() wrapper. Other functions from this
family could be similarly added as well, but it is not required for
this fix.