### PR TITLE
adding support for libc's "fgets" and "fgetc" needed for Ada language

### DIFF
--- a/compiler/Runtime.cpp
+++ b/compiler/Runtime.cpp
@@ -23,9 +23,9 @@ using namespace llvm;
 namespace {
 
 template <typename... ArgsTy>
-llvm::Value *import(llvm::Module &M, llvm::StringRef name, llvm::Type *ret,
+SymFnT import(llvm::Module &M, llvm::StringRef name, llvm::Type *ret,
                     ArgsTy... args) {
-#if LLVM_VERSION_MAJOR >= 9
+#if LLVM_VERSION_MAJOR >= 9 && LLVM_VERSION_MAJOR < 11
   return M.getOrInsertFunction(name, ret, args...).getCallee();
 #else
   return M.getOrInsertFunction(name, ret, args...);

--- a/compiler/Runtime.cpp
+++ b/compiler/Runtime.cpp
@@ -23,9 +23,9 @@ using namespace llvm;
 namespace {
 
 template <typename... ArgsTy>
-SymFnT import(llvm::Module &M, llvm::StringRef name, llvm::Type *ret,
+llvm::Value *import(llvm::Module &M, llvm::StringRef name, llvm::Type *ret,
                     ArgsTy... args) {
-#if LLVM_VERSION_MAJOR >= 9 && LLVM_VERSION_MAJOR < 11
+#if LLVM_VERSION_MAJOR >= 9
   return M.getOrInsertFunction(name, ret, args...).getCallee();
 #else
   return M.getOrInsertFunction(name, ret, args...);
@@ -158,10 +158,10 @@ Runtime::Runtime(Module &M) {
 /// Decide whether a function is called symbolically.
 bool isInterceptedFunction(const Function &f) {
   static const StringSet<> kInterceptedFunctions = {
-      "malloc",  "calloc",  "mmap",    "mmap64",  "open",   "read",     "lseek",
-      "lseek64", "fopen",   "fopen64", "fread",   "fseek",  "fseeko64", "getc",
-      "ungetc",  "memcpy",  "memset",  "strncpy", "strchr", "memcmp",   "memmove",
-      "ntohl"};
+      "malloc",   "calloc",  "mmap",    "mmap64",  "open",   "read",
+      "lseek",    "lseek64", "fopen",   "fopen64", "fread",  "fseek",
+      "fseeko64", "getc",    "ungetc",  "memcpy",  "memset", "strncpy",
+      "strchr",   "memcmp",  "memmove", "ntohl",   "fgets",  "fgetc"};
 
   return (kInterceptedFunctions.count(f.getName()) > 0);
 }

--- a/runtime/LibcWrappers.cpp
+++ b/runtime/LibcWrappers.cpp
@@ -251,15 +251,15 @@ char *SYM(fgets)(char *str, int n, FILE *stream) {
   tryAlternative(n, _sym_get_parameter_expression(1), SYM(fgets));
 
   auto result = fgets(str, n, stream);
-  _sym_set_return_expression(nullptr);
+  _sym_set_return_expression(_sym_get_parameter_expression(0));
 
   if (fileno(stream) == inputFileDescriptor) {
     // Reading symbolic input.
-    ReadWriteShadow shadow(str, sizeof(char) * n);
+    ReadWriteShadow shadow(str, sizeof(char) * strlen(str));
     std::generate(shadow.begin(), shadow.end(),
                   []() { return _sym_get_input_byte(inputOffset++); });
-  } else if (!isConcrete(str, sizeof(char) * n)) {
-    ReadWriteShadow shadow(str, sizeof(char) * n);
+  } else if (!isConcrete(str, sizeof(char) * strlen(str))) {
+    ReadWriteShadow shadow(str, sizeof(char) * strlen(str));
     std::fill(shadow.begin(), shadow.end(), nullptr);
   }
 

--- a/runtime/LibcWrappers.cpp
+++ b/runtime/LibcWrappers.cpp
@@ -246,6 +246,26 @@ size_t SYM(fread)(void *ptr, size_t size, size_t nmemb, FILE *stream) {
   return result;
 }
 
+char *SYM(fgets)(char *str, int n, FILE *stream) {
+  tryAlternative(str, _sym_get_parameter_expression(0), SYM(fgets));
+  tryAlternative(n, _sym_get_parameter_expression(1), SYM(fgets));
+
+  auto result = fgets(str, n, stream);
+  _sym_set_return_expression(nullptr);
+
+  if (fileno(stream) == inputFileDescriptor) {
+    // Reading symbolic input.
+    ReadWriteShadow shadow(str, sizeof(char) * n);
+    std::generate(shadow.begin(), shadow.end(),
+                  []() { return _sym_get_input_byte(inputOffset++); });
+  } else if (!isConcrete(str, sizeof(char) * n)) {
+    ReadWriteShadow shadow(str, sizeof(char) * n);
+    std::fill(shadow.begin(), shadow.end(), nullptr);
+  }
+
+  return result;
+}
+
 int SYM(fseek)(FILE *stream, long offset, int whence) {
   tryAlternative(offset, _sym_get_parameter_expression(1), SYM(fseek));
 
@@ -284,6 +304,22 @@ int SYM(fseeko64)(FILE *stream, uint64_t offset, int whence) {
 
 int SYM(getc)(FILE *stream) {
   auto result = getc(stream);
+  if (result == EOF) {
+    _sym_set_return_expression(nullptr);
+    return result;
+  }
+
+  if (fileno(stream) == inputFileDescriptor)
+    _sym_set_return_expression(_sym_build_zext(
+        _sym_get_input_byte(inputOffset++), sizeof(int) * 8 - 8));
+  else
+    _sym_set_return_expression(nullptr);
+
+  return result;
+}
+
+int SYM(fgetc)(FILE *stream) {
+  auto result = fgetc(stream);
   if (result == EOF) {
     _sym_set_return_expression(nullptr);
     return result;


### PR DESCRIPTION
These are libc functions used from Ada runtime libraries to read from standard input. 