### PR TITLE
added fseeko64 model (solve #16)

### DIFF
--- a/compiler/Runtime.cpp
+++ b/compiler/Runtime.cpp
@@ -158,9 +158,10 @@ Runtime::Runtime(Module &M) {
 /// Decide whether a function is called symbolically.
 bool isInterceptedFunction(const Function &f) {
   static const StringSet<> kInterceptedFunctions = {
-      "malloc",  "calloc",  "mmap",    "mmap64", "open",   "read",   "lseek",
-      "lseek64", "fopen",   "fopen64", "fread",  "fseek",  "getc",   "ungetc",
-      "memcpy",  "memset",  "strncpy", "strchr", "memcmp", "memmove", "ntohl"};
+      "malloc",  "calloc",  "mmap",    "mmap64",  "open",   "read",     "lseek",
+      "lseek64", "fopen",   "fopen64", "fread",   "fseek",  "fseeko64", "getc",
+      "ungetc",  "memcpy",  "memset",  "strncpy", "strchr", "memcmp",   "memmove",
+      "ntohl"};
 
   return (kInterceptedFunctions.count(f.getName()) > 0);
 }

--- a/runtime/LibcWrappers.cpp
+++ b/runtime/LibcWrappers.cpp
@@ -264,6 +264,24 @@ int SYM(fseek)(FILE *stream, long offset, int whence) {
   return result;
 }
 
+int SYM(fseeko64)(FILE *stream, long offset, int whence) {
+  tryAlternative(offset, _sym_get_parameter_expression(1), SYM(fseek));
+
+  auto result = fseeko64(stream, offset, whence);
+  _sym_set_return_expression(nullptr);
+  if (result == -1)
+    return result;
+
+  if (fileno(stream) == inputFileDescriptor) {
+    auto pos = ftello64(stream);
+    if (pos == -1)
+      return -1;
+    inputOffset = pos;
+  }
+
+  return result;
+}
+
 int SYM(getc)(FILE *stream) {
   auto result = getc(stream);
   if (result == EOF) {

--- a/runtime/LibcWrappers.cpp
+++ b/runtime/LibcWrappers.cpp
@@ -264,8 +264,8 @@ int SYM(fseek)(FILE *stream, long offset, int whence) {
   return result;
 }
 
-int SYM(fseeko64)(FILE *stream, long offset, int whence) {
-  tryAlternative(offset, _sym_get_parameter_expression(1), SYM(fseek));
+int SYM(fseeko64)(FILE *stream, uint64_t offset, int whence) {
+  tryAlternative(offset, _sym_get_parameter_expression(1), SYM(fseeko64));
 
   auto result = fseeko64(stream, offset, whence);
   _sym_set_return_expression(nullptr);


### PR DESCRIPTION
Hi!
I added the `fseeko64` model.
This solves #16 since `objdump` uses `fseeko64` instead of `fseek` to rewind the input stream. Since SYMCC does not have the `fseeko64` model, at some point a call to `fread` will increase the `inputOffset` beyond the input file dimension.
This causes QSYM to generate a read expression with an index greater than the input size, leading to an overflow when it tries to generate a new testcase ( `Solver::getConcreteValues` https://github.com/eurecom-s3/qsym/blob/d17a39d40dc3ea1d17262dd52607f8a6527dde10/qsym/pintool/solver.cpp#L308 ).