### PR TITLE
added fseeko and rewind models

### DIFF
--- a/compiler/Runtime.cpp
+++ b/compiler/Runtime.cpp
@@ -24,7 +24,7 @@ namespace {
 
 template <typename... ArgsTy>
 SymFnT import(llvm::Module &M, llvm::StringRef name, llvm::Type *ret,
-                    ArgsTy... args) {
+              ArgsTy... args) {
 #if LLVM_VERSION_MAJOR >= 9 && LLVM_VERSION_MAJOR < 11
   return M.getOrInsertFunction(name, ret, args...).getCallee();
 #else
@@ -158,10 +158,10 @@ Runtime::Runtime(Module &M) {
 /// Decide whether a function is called symbolically.
 bool isInterceptedFunction(const Function &f) {
   static const StringSet<> kInterceptedFunctions = {
-      "malloc",   "calloc",  "mmap",    "mmap64",  "open",   "read",
-      "lseek",    "lseek64", "fopen",   "fopen64", "fread",  "fseek",
-      "fseeko64", "getc",    "ungetc",  "memcpy",  "memset", "strncpy",
-      "strchr",   "memcmp",  "memmove", "ntohl",   "fgets",  "fgetc"};
+      "malloc",   "calloc",  "mmap",    "mmap64", "open",   "read",    "lseek",
+      "lseek64",  "fopen",   "fopen64", "fread",  "fseek",  "fseeko",  "rewind",
+      "fseeko64", "getc",    "ungetc",  "memcpy", "memset", "strncpy", "strchr",
+      "memcmp",   "memmove", "ntohl",   "fgets",  "fgetc"};
 
   return (kInterceptedFunctions.count(f.getName()) > 0);
 }

--- a/runtime/LibcWrappers.cpp
+++ b/runtime/LibcWrappers.cpp
@@ -266,6 +266,15 @@ char *SYM(fgets)(char *str, int n, FILE *stream) {
   return result;
 }
 
+void SYM(rewind)(FILE *stream) {
+  rewind(stream);
+  _sym_set_return_expression(nullptr);
+
+  if (fileno(stream) == inputFileDescriptor) {
+    inputOffset = 0;
+  }
+}
+
 int SYM(fseek)(FILE *stream, long offset, int whence) {
   tryAlternative(offset, _sym_get_parameter_expression(1), SYM(fseek));
 
@@ -276,6 +285,24 @@ int SYM(fseek)(FILE *stream, long offset, int whence) {
 
   if (fileno(stream) == inputFileDescriptor) {
     auto pos = ftell(stream);
+    if (pos == -1)
+      return -1;
+    inputOffset = pos;
+  }
+
+  return result;
+}
+
+int SYM(fseeko)(FILE *stream, off_t offset, int whence) {
+  tryAlternative(offset, _sym_get_parameter_expression(1), SYM(fseeko));
+
+  auto result = fseeko(stream, offset, whence);
+  _sym_set_return_expression(nullptr);
+  if (result == -1)
+    return result;
+
+  if (fileno(stream) == inputFileDescriptor) {
+    auto pos = ftello(stream);
     if (pos == -1)
       return -1;
     inputOffset = pos;
@@ -464,8 +491,7 @@ int SYM(memcmp)(const void *a, const void *b, size_t n) {
   return result;
 }
 
-uint32_t SYM(ntohl)(uint32_t netlong)
-{
+uint32_t SYM(ntohl)(uint32_t netlong) {
   auto netlongExpr = _sym_get_parameter_expression(0);
   auto result = ntohl(netlong);
 
@@ -484,5 +510,4 @@ uint32_t SYM(ntohl)(uint32_t netlong)
 
   return result;
 }
-
 }


### PR DESCRIPTION
Hi!
This is related to #40. I added the `rewind` and `fseeko` models.
Readelf had a similar issue wrt objdump in #16, but with rewind. To reproduce the issue:

`SYMCC_INPUT_FILE=crashing_input readelf -a crashing_input`
[crashing_input.zip](https://github.com/eurecom-s3/symcc/files/5829067/crashing_input.zip)
