### PR TITLE
Fixes #44 and #45, adds -Q, -W, -S option, afl++ support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 \
 -Wredundant-decls -Wcast-align -Wmissing-include-dirs -Wswitch-default \
 -Wextra -Wall -Winvalid-pch -Wredundant-decls -Wformat=2 \
--Wmissing-format-attribute -Wformat-nonliteral -Werror")
+-Wmissing-format-attribute -Wformat-nonliteral")
 
 # Mark nodelete to work around unload bug in upstream LLVM 5.0+
 set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -Wl,-z,nodelete")

--- a/runtime/simple_backend/CMakeLists.txt
+++ b/runtime/simple_backend/CMakeLists.txt
@@ -39,4 +39,4 @@ target_include_directories(SymRuntime PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/..
   ${Z3_C_INCLUDE_DIRS})
 
-set_target_properties(SymRuntime PROPERTIES COMPILE_FLAGS "-Werror")
+set_target_properties(SymRuntime PROPERTIES COMPILE_FLAGS)

--- a/util/symcc_fuzzing_helper/src/main.rs
+++ b/util/symcc_fuzzing_helper/src/main.rs
@@ -310,10 +310,12 @@ fn main() -> Result<()> {
     log::debug!("SymCC configuration: {:?}", &symcc);
     let mut afl_config = AflConfig::load(options.output_dir.join(&options.fuzzer_name))?;
     if options.force_qemu_mode && !afl_config.use_qemu_mode {
-      // We need to overwrite the binary afl-showmap is running as the one
-      // in the afl config is an instrumented one!
-      afl_config.target_command[0] = OsString::from(options.command[0].clone()).to_os_string();
-      afl_config.use_qemu_mode = true;
+        // We need to overwrite the binary afl-showmap is running as the one
+        // in the afl config is an instrumented one
+        if options.command[0].contains("symqemu") {
+            afl_config.target_command[1] = OsString::from(options.command[1].clone()).to_os_string();
+        }
+        afl_config.use_qemu_mode = true;
     }
     log::debug!("AFL configuration: {:?}", &afl_config);
     let mut state = State::initialize(symcc_dir)?;

--- a/util/symcc_fuzzing_helper/src/main.rs
+++ b/util/symcc_fuzzing_helper/src/main.rs
@@ -56,7 +56,7 @@ struct CLI {
     force_qemu_mode: bool,
 
     /// starting ID in the sync fuzzer queue - a poor person's restart option
-    #[structopt(short = "S")]
+    #[structopt(short = "S", default_value("0"), required(false))]
     start_id: u32,
 
     /// Program under test

--- a/util/symcc_fuzzing_helper/src/main.rs
+++ b/util/symcc_fuzzing_helper/src/main.rs
@@ -363,7 +363,7 @@ fn process_new_testcase(
                 "Failed to check whether test case {} is interesting",
                 &testcase.as_ref().display()
             )
-        })? {
+        }).unwrap_or(AflShowmapResult::Ignore) {
         AflShowmapResult::Ignore => {
             log::info!("afl-showmap error'ed, ignoring");
             Ok(TestcaseResult::Uninteresting)

--- a/util/symcc_fuzzing_helper/src/main.rs
+++ b/util/symcc_fuzzing_helper/src/main.rs
@@ -23,7 +23,6 @@ use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::{Duration, Instant};
 use std::ffi::OsString;
-use std::str::FromStr;
 use structopt::StructOpt;
 use symcc::{AflConfig, AflMap, AflShowmapResult, SymCC, TestcaseDir};
 use tempfile::tempdir;
@@ -338,7 +337,7 @@ fn main() -> Result<()> {
                 let filename = input.file_name().unwrap().to_string_lossy();
                 if filename.starts_with("id:") {
                     let id_str = filename.get(3..9).unwrap();
-                    let id = FromStr::from_str(id_str).unwrap_or(0);
+                    let id = id_str.parse().unwrap_or(0);
                     if id >= options.start_id {
                         state.test_input(&input, &symcc, &afl_config)?
                     } else {

--- a/util/symcc_fuzzing_helper/src/symcc.rs
+++ b/util/symcc_fuzzing_helper/src/symcc.rs
@@ -338,6 +338,7 @@ impl AflConfig {
             .args(&["-t", "5000", "-m", "none", "-b", "-o"])
             .arg(testcase_bitmap.as_ref())
             .args(insert_input_file(&self.target_command, &testcase))
+            .env("AFL_MAP_SIZE", "65535")  // req for afl++
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .stdin(if self.use_standard_input {

--- a/util/symcc_fuzzing_helper/src/symcc.rs
+++ b/util/symcc_fuzzing_helper/src/symcc.rs
@@ -225,7 +225,7 @@ pub struct AflConfig {
     show_map: PathBuf,
 
     /// The command that AFL uses to invoke the target program.
-    target_command: Vec<OsString>,
+    pub target_command: Vec<OsString>,
 
     /// Do we need to pass data to standard input?
     use_standard_input: bool,

--- a/util/symcc_fuzzing_helper/src/symcc.rs
+++ b/util/symcc_fuzzing_helper/src/symcc.rs
@@ -383,7 +383,6 @@ impl AflConfig {
             1 => Ok(AflShowmapResult::Hang),
             2 => Ok(AflShowmapResult::Crash),
             _ => Ok(AflShowmapResult::Ignore),
-            //panic!("Unexpected return code {} from afl-showmap", unexpected),
         }
     }
 }


### PR DESCRIPTION
changes the error handling so that symcc_fuzzing_helper continues at all cost.
because without the ability to resume it is pretty pointless to run it otherwise.
It also adds the -Q option which forces afl-showmap qemu mode (so we can run symqemu although we fuzz an instrumented binary. for cases where symc++ fails for the target, and we do not want to waste an afl-fuzz-Q specifically for for symcc)