### PR TITLE
libwrappers: symbolic getchar

### DIFF
--- a/compiler/Runtime.cpp
+++ b/compiler/Runtime.cpp
@@ -163,7 +163,7 @@ bool isInterceptedFunction(const Function &f) {
       "malloc",   "calloc",  "mmap",    "mmap64", "open",   "read",    "lseek",
       "lseek64",  "fopen",   "fopen64", "fread",  "fseek",  "fseeko",  "rewind",
       "fseeko64", "getc",    "ungetc",  "memcpy", "memset", "strncpy", "strchr",
-      "memcmp",   "memmove", "ntohl",   "fgets",  "fgetc"};
+      "memcmp",   "memmove", "ntohl",   "fgets",  "fgetc", "getchar"};
 
   return (kInterceptedFunctions.count(f.getName()) > 0);
 }

--- a/runtime/LibcWrappers.cpp
+++ b/runtime/LibcWrappers.cpp
@@ -361,6 +361,10 @@ int SYM(fgetc)(FILE *stream) {
   return result;
 }
 
+int SYM(getchar)(void) {
+  return SYM(getc)(stdin);
+}
+
 int SYM(ungetc)(int c, FILE *stream) {
   auto result = ungetc(c, stream);
   _sym_set_return_expression(_sym_get_parameter_expression(0));


### PR DESCRIPTION
Per the man page,

```
getchar() is equivalent to getc(stdin).
```