### PR TITLE
test: fix tests

### DIFF
--- a/test/bswap.c
+++ b/test/bswap.c
@@ -24,6 +24,10 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 
+#if defined(ntohl)
+#undef ntohl
+#endif
+
 int main(int argc, char* argv[]) {
   uint32_t x;
   if (read(STDIN_FILENO, &x, sizeof(x)) != sizeof(x)) {

--- a/test/file_input.c
+++ b/test/file_input.c
@@ -23,6 +23,10 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#if defined(ntohl)
+#undef ntohl
+#endif
+
 int main(int argc, char* argv[]) {
   //
   // Read from the input file using Unix primitives.

--- a/test/floats.c
+++ b/test/floats.c
@@ -21,6 +21,10 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 
+#if defined(ntohl)
+#undef ntohl
+#endif
+
 float g_value = 0.1234;
 
 int main(int argc, char *argv[]) {

--- a/test/globals.c
+++ b/test/globals.c
@@ -25,6 +25,10 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 
+#if defined(ntohl)
+#undef ntohl
+#endif
+
 int g_increment = 17;
 int g_uninitialized;
 int g_more_than_one_byte_int = 512;

--- a/test/large_alloc.c
+++ b/test/large_alloc.c
@@ -25,6 +25,10 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 
+#if defined(ntohl)
+#undef ntohl
+#endif
+
 int main(int argc, char *argv[]) {
   int x;
   if (read(STDIN_FILENO, &x, sizeof(x)) != sizeof(x)) {

--- a/test/loop.c
+++ b/test/loop.c
@@ -30,6 +30,10 @@
 #define MYINT int64_t
 #endif
 
+#if defined(ntohl)
+#undef ntohl
+#endif
+
 int fac(int x) {
     MYINT result = 1;
 

--- a/test/memcpy.c
+++ b/test/memcpy.c
@@ -27,6 +27,10 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
+#if defined(ntohl)
+#undef ntohl
+#endif
+
 int main(int argc, char *argv[]) {
   char values[] = {1, 2, 3};
   char values_copy[3];

--- a/test/pointers.c
+++ b/test/pointers.c
@@ -21,6 +21,10 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 
+#if defined(ntohl)
+#undef ntohl
+#endif
+
 volatile int g_value;
 
 int main(int argc, char* argv[]) {

--- a/test/structs.c
+++ b/test/structs.c
@@ -21,6 +21,10 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 
+#if defined(ntohl)
+#undef ntohl
+#endif
+
 struct point {
     int x;
     int y;

--- a/test/switch.c
+++ b/test/switch.c
@@ -23,6 +23,10 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 
+#if defined(ntohl)
+#undef ntohl
+#endif
+
 int main(int argc, char* argv[]) {
   int x;
   if (read(STDIN_FILENO, &x, sizeof(x)) != sizeof(x)) {


### PR DESCRIPTION
Includes disabling `-O2` optimization, because newer LLVM's insert inline assembly which loses symbolic constraints.