### PR TITLE
Handle concrete Booleans in load/store

### DIFF
--- a/runtime/RuntimeCommon.cpp
+++ b/runtime/RuntimeCommon.cpp
@@ -233,6 +233,9 @@ void symcc_make_symbolic(void *start, size_t byte_length) {
 }
 
 SymExpr _sym_build_bit_to_bool(SymExpr expr) {
+  if (expr == nullptr)
+    return nullptr;
+
   return _sym_build_not_equal(expr,
                               _sym_build_integer(0, _sym_bits_helper(expr)));
 }

--- a/runtime/qsym_backend/Runtime.cpp
+++ b/runtime/qsym_backend/Runtime.cpp
@@ -275,16 +275,25 @@ SymExpr _sym_build_not(SymExpr expr) {
 }
 
 SymExpr _sym_build_sext(SymExpr expr, uint8_t bits) {
+  if (expr == nullptr)
+    return nullptr;
+
   return registerExpression(g_expr_builder->createSExt(
       allocatedExpressions.at(expr), bits + expr->bits()));
 }
 
 SymExpr _sym_build_zext(SymExpr expr, uint8_t bits) {
+  if (expr == nullptr)
+    return nullptr;
+
   return registerExpression(g_expr_builder->createZExt(
       allocatedExpressions.at(expr), bits + expr->bits()));
 }
 
 SymExpr _sym_build_trunc(SymExpr expr, uint8_t bits) {
+  if (expr == nullptr)
+    return nullptr;
+
   return registerExpression(
       g_expr_builder->createTrunc(allocatedExpressions.at(expr), bits));
 }
@@ -315,6 +324,9 @@ SymExpr _sym_extract_helper(SymExpr expr, size_t first_bit, size_t last_bit) {
 size_t _sym_bits_helper(SymExpr expr) { return expr->bits(); }
 
 SymExpr _sym_build_bool_to_bit(SymExpr expr) {
+  if (expr == nullptr)
+    return nullptr;
+
   return registerExpression(
       g_expr_builder->boolToBit(allocatedExpressions.at(expr), 1));
 }

--- a/runtime/simple_backend/Runtime.cpp
+++ b/runtime/simple_backend/Runtime.cpp
@@ -351,14 +351,21 @@ Z3_ast _sym_build_float_unordered_not_equal(Z3_ast a, Z3_ast b) {
 }
 
 Z3_ast _sym_build_sext(Z3_ast expr, uint8_t bits) {
+  if (expr == nullptr)
+    return nullptr;
   return registerExpression(Z3_mk_sign_ext(g_context, bits, expr));
 }
 
 Z3_ast _sym_build_zext(Z3_ast expr, uint8_t bits) {
+  if (expr == nullptr)
+    return nullptr;
   return registerExpression(Z3_mk_zero_ext(g_context, bits, expr));
 }
 
 Z3_ast _sym_build_trunc(Z3_ast expr, uint8_t bits) {
+  if (expr == nullptr)
+    return nullptr;
+
   return registerExpression(Z3_mk_extract(g_context, bits - 1, 0, expr));
 }
 
@@ -410,6 +417,8 @@ Z3_ast _sym_build_float_to_unsigned_integer(Z3_ast expr, uint8_t bits) {
 }
 
 Z3_ast _sym_build_bool_to_bit(Z3_ast expr) {
+  if (expr == nullptr)
+    return nullptr;
   return registerExpression(Z3_mk_ite(g_context, expr, _sym_build_integer(1, 1),
                                       _sym_build_integer(0, 1)));
 }

--- a/test/load_store.ll
+++ b/test/load_store.ll
@@ -1,0 +1,45 @@
+; This file is part of SymCC.
+;
+; SymCC is free software: you can redistribute it and/or modify it under the
+; terms of the GNU General Public License as published by the Free Software
+; Foundation, either version 3 of the License, or (at your option) any later
+; version.
+;
+; SymCC is distributed in the hope that it will be useful, but WITHOUT ANY
+; WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+; A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+;
+; You should have received a copy of the GNU General Public License along with
+; SymCC. If not, see <https://www.gnu.org/licenses/>.
+
+; Verify that loading and storing concrete values of various types works. For
+; each type, we allocate space on the stack, then store a constant value into
+; it, and finally load it back. Compiling this code with SymCC and verifying
+; that the resulting binary exits cleanly shows that SymCC's instrumentation
+; doesn't break the load/store operations.
+;
+; This test reproduces a bug where loading a concrete Boolean would lead to a
+; program crash.
+;
+; Since the bitcode is written by hand, we first run llc on it because it
+; performs a validity check, whereas Clang doesn't.
+;
+; RUN: llc %s -o /dev/null
+; RUN: %symcc %s -o %t
+; RUN: %t 2>&1
+
+target triple = "x86_64-pc-linux-gnu"
+
+define i32 @main(i32 %argc, i8** %argv) {
+  ; Load and store a Boolean.
+  %stack_bool = alloca i1
+  store i1 0, i1* %stack_bool
+  %copy_of_stack_bool = load i1, i1* %stack_bool
+
+  ; Load and store a float.
+  %stack_float = alloca float
+  store float 0.0, float* %stack_float
+  %copy_of_stack_float = load float, float* %stack_float
+
+  ret i32 0
+}


### PR DESCRIPTION
The code introduced to fix eurecom-s3/symcc#112 can't handle concrete values (i.e., `nullptr` expressions). Detecting `nullptr` and skipping the symbolic computations in bitcode would have complicated the code of the pass and the generated IR a lot for an unclear benefit (basically just preventing the call to and immediate return from the runtime functions).