### PR TITLE
Support test-case handlers in instrumented code

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -26,6 +26,7 @@ jobs:
           submodules: true
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y \
             llvm-${{ matrix.llvm_version }}-dev \
             libz3-dev \

--- a/runtime/qsym_backend/Runtime.cpp
+++ b/runtime/qsym_backend/Runtime.cpp
@@ -137,6 +137,12 @@ public:
   void saveValues(const std::string &suffix) override {
     if (auto handler = g_test_case_handler) {
       auto values = getConcreteValues();
+      // The test-case handler may be instrumented, so let's call it with
+      // argument expressions to meet instrumented code's expectations.
+      // Otherwise, we might end up erroneously using whatever expression was
+      // last registered for a function parameter.
+      _sym_set_parameter_expression(0, nullptr);
+      _sym_set_parameter_expression(1, nullptr);
       handler(values.data(), values.size());
     } else {
       Solver::saveValues(suffix);


### PR DESCRIPTION
This commit fixes eurecom-s3/symcc#140 by calling the test-case handler with the proper calling convention for instrumented code, i.e., setting parameter expressions before the call.