### PR TITLE
Fix issues with floats and Booleans in structs

### DIFF
--- a/compiler/Symbolizer.h
+++ b/compiler/Symbolizer.h
@@ -202,7 +202,7 @@ private:
   };
 
   /// Create an expression that represents the concrete value.
-  llvm::CallInst *createValueExpression(llvm::Value *V, llvm::IRBuilder<> &IRB);
+  llvm::Instruction *createValueExpression(llvm::Value *V, llvm::IRBuilder<> &IRB);
 
   /// Get the (already created) symbolic expression for a value.
   llvm::Value *getSymbolicExpression(llvm::Value *V) const {
@@ -318,15 +318,15 @@ private:
                                                  llvm::Instruction *I,
                                                  llvm::Type *T) const;
 
-  /// Emit code that converts the expression in I to a bit-vector expression.
-  /// Return the SymbolicComputation representing the conversion (if a
-  /// conversion is necessary); the last instruction computes the result.
+  /// Emit code that converts the expression Expr for V to a bit-vector
+  /// expression. Return the SymbolicComputation representing the conversion
+  /// (if a conversion is necessary); the last instruction computes the result.
   ///
   /// This is the inverse operation of convertBitVectorExprForType (see details
   /// there).
   std::optional<SymbolicComputation>
   convertExprForTypeToBitVectorExpr(llvm::IRBuilder<> &IRB,
-                                    llvm::Value *V) const;
+                                    llvm::Value *V, llvm::Value *Expr) const;
 
   const Runtime runtime;
 

--- a/compiler/Symbolizer.h
+++ b/compiler/Symbolizer.h
@@ -202,7 +202,8 @@ private:
   };
 
   /// Create an expression that represents the concrete value.
-  llvm::Instruction *createValueExpression(llvm::Value *V, llvm::IRBuilder<> &IRB);
+  llvm::Instruction *createValueExpression(llvm::Value *V,
+                                           llvm::IRBuilder<> &IRB);
 
   /// Get the (already created) symbolic expression for a value.
   llvm::Value *getSymbolicExpression(llvm::Value *V) const {
@@ -325,8 +326,8 @@ private:
   /// This is the inverse operation of convertBitVectorExprForType (see details
   /// there).
   std::optional<SymbolicComputation>
-  convertExprForTypeToBitVectorExpr(llvm::IRBuilder<> &IRB,
-                                    llvm::Value *V, llvm::Value *Expr) const;
+  convertExprForTypeToBitVectorExpr(llvm::IRBuilder<> &IRB, llvm::Value *V,
+                                    llvm::Value *Expr) const;
 
   const Runtime runtime;
 

--- a/runtime/qsym_backend/Runtime.cpp
+++ b/runtime/qsym_backend/Runtime.cpp
@@ -347,10 +347,27 @@ SymExpr _sym_build_bool_to_bit(SymExpr expr) {
 // Floating-point operations (unsupported in QSYM)
 //
 
+// Even if we don't generally support operations on floats in this backend, we
+// need dummy implementations of a few functions to help the parts of the
+// instrumentation that deal with structures; if structs contain floats, the
+// instrumentation expects to be able to create bit-vector expressions for
+// them.
+
+SymExpr _sym_build_float(double, int is_double) {
+  // We create an all-zeros bit vector, mainly to capture the length of the
+  // value. This is compatible with our dummy implementation of
+  // _sym_build_float_to_bits.
+  return registerExpression(
+      g_expr_builder->createConstant(0, is_double ? 64 : 32));
+}
+
+SymExpr _sym_build_float_to_bits(SymExpr expr) {
+  return expr;
+}
+
 #define UNSUPPORTED(prototype)                                                 \
   prototype { return nullptr; }
 
-UNSUPPORTED(SymExpr _sym_build_float(double, int))
 UNSUPPORTED(SymExpr _sym_build_fp_add(SymExpr, SymExpr))
 UNSUPPORTED(SymExpr _sym_build_fp_sub(SymExpr, SymExpr))
 UNSUPPORTED(SymExpr _sym_build_fp_mul(SymExpr, SymExpr))
@@ -375,7 +392,6 @@ UNSUPPORTED(SymExpr _sym_build_float_unordered_not_equal(SymExpr, SymExpr))
 UNSUPPORTED(SymExpr _sym_build_int_to_float(SymExpr, int, int))
 UNSUPPORTED(SymExpr _sym_build_float_to_float(SymExpr, int))
 UNSUPPORTED(SymExpr _sym_build_bits_to_float(SymExpr, int))
-UNSUPPORTED(SymExpr _sym_build_float_to_bits(SymExpr))
 UNSUPPORTED(SymExpr _sym_build_float_to_signed_integer(SymExpr, uint8_t))
 UNSUPPORTED(SymExpr _sym_build_float_to_unsigned_integer(SymExpr, uint8_t))
 

--- a/runtime/qsym_backend/Runtime.cpp
+++ b/runtime/qsym_backend/Runtime.cpp
@@ -361,9 +361,7 @@ SymExpr _sym_build_float(double, int is_double) {
       g_expr_builder->createConstant(0, is_double ? 64 : 32));
 }
 
-SymExpr _sym_build_float_to_bits(SymExpr expr) {
-  return expr;
-}
+SymExpr _sym_build_float_to_bits(SymExpr expr) { return expr; }
 
 #define UNSUPPORTED(prototype)                                                 \
   prototype { return nullptr; }

--- a/test/symbolic_structs.ll
+++ b/test/symbolic_structs.ll
@@ -1,0 +1,52 @@
+; This file is part of SymCC.
+;
+; SymCC is free software: you can redistribute it and/or modify it under the
+; terms of the GNU General Public License as published by the Free Software
+; Foundation, either version 3 of the License, or (at your option) any later
+; version.
+;
+; SymCC is distributed in the hope that it will be useful, but WITHOUT ANY
+; WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+; A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+;
+; You should have received a copy of the GNU General Public License along with
+; SymCC. If not, see <https://www.gnu.org/licenses/>.
+
+; Verify that we correctly insert into symbolic struct values. We insert values
+; of various types into a symbolic struct, thus triggering expression updates.
+; Compiling this code with SymCC and verifying that the resulting binary exits
+; cleanly shows that SymCC's instrumentation doesn't break the execution of the
+; program.
+;
+; This test reproduces a bug where inserting a concrete floating-point value
+; into a symbolic struct would lead to a program crash (eurecom-s3/symcc#138).
+;
+; Since the bitcode is written by hand, we first run llc on it because it
+; performs a validity check, whereas Clang doesn't.
+
+; RUN: llc %s -o /dev/null
+; RUN: %symcc %s -o %t
+; RUN: env SYMCC_MEMORY_INPUT=1 %t 2>&1
+
+target triple = "x86_64-pc-linux-gnu"
+
+; The struct type of our symbolic value. Include a floating-point value and a
+; Boolean because they're represented with non-bitvector solver variables
+; (reproducing eurecom-s3/symcc#138).
+%struct_type = type { i8, i32, i8, float, i1 }
+
+define i32 @main(i32 %argc, i8** %argv) {
+  ; Create a symbolic struct value that we can subsequently insert values into.
+  %struct_value_mem = alloca %struct_type
+  call void @symcc_make_symbolic(%struct_type* %struct_value_mem, i64 20)
+  %symbolic_struct = load %struct_type, %struct_type* %struct_value_mem
+
+  ; Insert values of various types, triggering the creation of new expressions.
+  insertvalue %struct_type %symbolic_struct, i32 5, 1
+  insertvalue %struct_type %symbolic_struct, float 42.0, 3
+  insertvalue %struct_type %symbolic_struct, i1 1, 4
+
+  ret i32 0
+}
+
+declare void @symcc_make_symbolic(%struct_type*, i64)


### PR DESCRIPTION
These commits fix problems with symbolic expressions for floats and Booleans in structs, which were caused by the fact that the SMT solver represents those types of values with expressions of non-bitvector kind.