### PR TITLE
Make symcc work with llvm 17

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        llvm_version: [16] # 17]
+        llvm_version: [16, 17]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,8 @@ find_package(LLVM REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake from ${LLVM_DIR}")
 
-if (${LLVM_VERSION_MAJOR} LESS 8 OR ${LLVM_VERSION_MAJOR} GREATER 16)
-  message(WARNING "The software has been developed for LLVM 8 through 16; \
+if (${LLVM_VERSION_MAJOR} LESS 8 OR ${LLVM_VERSION_MAJOR} GREATER 17)
+  message(WARNING "The software has been developed for LLVM 8 through 17; \
 it is unlikely to work with other versions!")
 endif()
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ program. The actual computation happens through calls to the support library at
 run time.
 
 To build the pass and the support library, install LLVM (any version between 8
-and 16) and Z3 (version 4.5 or later), as well as a C++ compiler with support
+and 17) and Z3 (version 4.5 or later), as well as a C++ compiler with support
 for C++17. LLVM lit is only needed to run the tests; if it's not packaged with
 your LLVM, you can get it with `pip install lit`.
 

--- a/compiler/Main.cpp
+++ b/compiler/Main.cpp
@@ -14,7 +14,7 @@
 
 #include <llvm/IR/LegacyPassManager.h>
 #if LLVM_VERSION_MAJOR <= 15
-  #include <llvm/Transforms/IPO/PassManagerBuilder.h>
+#include <llvm/Transforms/IPO/PassManagerBuilder.h>
 #endif
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Scalar/Scalarizer.h>

--- a/compiler/Main.cpp
+++ b/compiler/Main.cpp
@@ -13,7 +13,9 @@
 // SymCC. If not, see <https://www.gnu.org/licenses/>.
 
 #include <llvm/IR/LegacyPassManager.h>
-#include <llvm/Transforms/IPO/PassManagerBuilder.h>
+#if LLVM_VERSION_MAJOR <= 15
+  #include <llvm/Transforms/IPO/PassManagerBuilder.h>
+#endif
 #include <llvm/Transforms/Scalar.h>
 #include <llvm/Transforms/Scalar/Scalarizer.h>
 


### PR DESCRIPTION
llvm/Transforms/IPO/PassManagerBuilder.h doesn't exist on llvm 17