### PR TITLE
Drop python2 usage

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -30,7 +30,6 @@ jobs:
           sudo apt-get install -y \
             llvm-${{ matrix.llvm_version }}-dev \
             libz3-dev \
-            python2
       - name: Build SymCC with the QSYM backend
         run: |
           mkdir build
@@ -64,7 +63,6 @@ jobs:
           sudo apt-get install -y \
             llvm-${{ matrix.llvm_version }}-dev \
             libz3-dev \
-            python2
       - name: Build SymCC with the QSYM backend
         run: |
           mkdir build

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN apt-get update \
         llvm-15-dev \
         llvm-15-tools \
         ninja-build \
-        python2 \
         python3-pip \
         zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Under Ubuntu Groovy the following one liner should install all required
 packages:
 
 ```
-sudo apt install -y git cargo clang-14 cmake g++ git libz3-dev llvm-14-dev llvm-14-tools ninja-build python2 python3-pip zlib1g-dev && sudo pip3 install lit
+sudo apt install -y git cargo clang-14 cmake g++ git libz3-dev llvm-14-dev llvm-14-tools ninja-build python3-pip zlib1g-dev && sudo pip3 install lit
 ```
 
 Alternatively, see below for using the provided Dockerfile, or the file

--- a/runtime/qsym_backend/CMakeLists.txt
+++ b/runtime/qsym_backend/CMakeLists.txt
@@ -17,24 +17,6 @@
 
 set(QSYM_SOURCE_DIR "qsym/qsym/pintool")
 
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/expr__gen.cpp
-  COMMAND python2 gen_expr.py ${CMAKE_CURRENT_BINARY_DIR}
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${QSYM_SOURCE_DIR}/codegen
-  COMMENT "Generating Qsym's expr__gen.cpp"
-  VERBATIM
-  DEPENDS
-  ${QSYM_SOURCE_DIR}/codegen/expr.cpp
-  ${QSYM_SOURCE_DIR}/codegen/gen_expr.py)
-
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/expr_builder__gen.cpp
-  COMMAND python2 gen_expr_builder.py ${CMAKE_CURRENT_BINARY_DIR}
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${QSYM_SOURCE_DIR}/codegen
-  COMMENT "Generating Qsym's expr__gen.cpp"
-  VERBATIM
-  DEPENDS
-  ${QSYM_SOURCE_DIR}/codegen/expr_builder.cpp
-  ${QSYM_SOURCE_DIR}/codegen/gen_expr_builder.py)
-
 find_package(LLVM REQUIRED CONFIG)
 add_definitions(${LLVM_DEFINITIONS})
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
@@ -57,8 +39,8 @@ configure CMake with -DZ3_TRUST_SYSTEM_VERSION=on (see also docs/Configuration.t
 endif()
 
 add_library(SymRuntime SHARED
-  ${CMAKE_CURRENT_BINARY_DIR}/expr__gen.cpp
-  ${CMAKE_CURRENT_BINARY_DIR}/expr_builder__gen.cpp
+  ${QSYM_SOURCE_DIR}/expr.cpp
+  ${QSYM_SOURCE_DIR}/expr_builder.cpp
   ${QSYM_SOURCE_DIR}/expr_cache.cpp
   ${QSYM_SOURCE_DIR}/expr_evaluate.cpp
   ${QSYM_SOURCE_DIR}/solver.cpp

--- a/util/quicktest.sh
+++ b/util/quicktest.sh
@@ -19,7 +19,7 @@ sudo apt-get update
 sudo apt-get upgrade -y
 
 # install requirements
-sudo apt-get install -y git cargo clang-10 cmake g++ git libz3-dev llvm-10-dev llvm-10-tools ninja-build python2 python3-pip zlib1g-dev
+sudo apt-get install -y git cargo clang-10 cmake g++ git libz3-dev llvm-10-dev llvm-10-tools ninja-build python3-pip zlib1g-dev
 sudo pip3 install lit
 
 # Clone project 


### PR DESCRIPTION
Hi,

here is an update to SymCC related to https://github.com/eurecom-s3/qsym/pull/5. All python2 references has been removed, because python2 is dead.

PR is in draft because first https://github.com/eurecom-s3/qsym/pull/5 has to be merged to properly update submodule.