### PR TITLE
Make the string buffer of _sym_expr_to_string externally allocated

### DIFF
--- a/runtime/RuntimeCommon.h
+++ b/runtime/RuntimeCommon.h
@@ -210,7 +210,7 @@ void _sym_notify_basic_block(uintptr_t site_id);
  * Debugging
  */
 // Puts the string associated to expr in buf.
-// If bufsize is not big enough, returns the size of expr's string.
+// If buf_size is not big enough, returns the size of expr's string.
 // Otherwise, returns 0.
 size_t _sym_expr_to_string(SymExpr expr, char* buf, size_t buf_size);
 bool _sym_feasible(SymExpr expr);

--- a/runtime/RuntimeCommon.h
+++ b/runtime/RuntimeCommon.h
@@ -209,7 +209,10 @@ void _sym_notify_basic_block(uintptr_t site_id);
 /*
  * Debugging
  */
-const char *_sym_expr_to_string(SymExpr expr); // statically allocated
+// Puts the string associated to expr in buf.
+// If bufsize is not big enough, returns the size of expr's string.
+// Otherwise, returns 0.
+size_t _sym_expr_to_string(SymExpr expr, char* buf, size_t buf_size);
 bool _sym_feasible(SymExpr expr);
 
 /*

--- a/runtime/qsym_backend/Runtime.cpp
+++ b/runtime/qsym_backend/Runtime.cpp
@@ -422,15 +422,18 @@ void _sym_notify_basic_block(uintptr_t site_id) {
 // Debugging
 //
 
-const char *_sym_expr_to_string(SymExpr expr) {
-  static char buffer[4096];
+size_t _sym_expr_to_string(SymExpr expr, char* buf, size_t buf_size) {
+  std::string expr_string = expr->toString();
+  size_t expr_string_size = expr_string.size();
 
-  auto expr_string = expr->toString();
-  auto copied = expr_string.copy(
-      buffer, std::min(expr_string.length(), sizeof(buffer) - 1));
-  buffer[copied] = '\0';
+  if (expr_string_size + 1 > buf_size) {
+    return expr_string_size;
+  }
 
-  return buffer;
+  strncpy(buf, expr->toString().c_str(), expr_string_size);
+  buf[expr_string_size] = '\0';
+
+  return 0;
 }
 
 bool _sym_feasible(SymExpr expr) {

--- a/runtime/simple_backend/Runtime.cpp
+++ b/runtime/simple_backend/Runtime.cpp
@@ -512,8 +512,18 @@ void _sym_notify_ret(uintptr_t) {}
 void _sym_notify_basic_block(uintptr_t) {}
 
 /* Debugging */
-const char *_sym_expr_to_string(SymExpr expr) {
-  return Z3_ast_to_string(g_context, expr);
+size_t _sym_expr_to_string(SymExpr expr, char* buf, size_t buf_size) {
+  char* expr_string = Z3_ast_to_string(g_context, expr);
+  size_t expr_string_size = strlen(expr_string_size);
+
+  if (expr_string_size + 1 > buf_size) {
+    return expr_string_size;
+  }
+
+  strncpy(buf, expr_string, expr_string_size);
+  buf[expr_string_size] = '\0';
+
+  return 0;
 }
 
 bool _sym_feasible(SymExpr expr) {


### PR DESCRIPTION
For now, `_sym_expr_to_string` puts the string in an internal buffer limited to 4096 bytes.

This PR proposes to let the user create the buffer and manage its size externally, to avoid having issues for large-sized expressions.