### PR TITLE
Fix conditions to push docker image

### DIFF
--- a/.github/workflows/create_push_docker_image.yml
+++ b/.github/workflows/create_push_docker_image.yml
@@ -1,19 +1,11 @@
 name: Publish SymCC Docker image
-# for testing only
-#on: [pull_request, workflow_dispatch]
-#
-# we want to push a docker image when the  Compile and test SymCC
-# workflow completed successfully
 on:
-  workflow_run:
-    workflows: [Compile and test SymCC]
-    branches: master
-    types:
-      - completed
+  push:
+    branches: ['master']
 
 jobs:
   upload_dockerhub:
-    if: ${{ (github.repository == 'eurecom-s3/symcc') && (github.ref == 'refs/heads/master') && (github.event.workflow_run.conclusion == 'success') }}
+    if: ${{ (github.repository == 'eurecom-s3/symcc') && (github.ref == 'refs/heads/master') }}
     runs-on: ubuntu-latest
     steps:
     -


### PR DESCRIPTION
We don't run the tests on master (as they have been run before merge). Just create the docker image and push it.