### PR TITLE
Add Docker smoke test for README C testcase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 #
 FROM ubuntu:22.04 AS builder
 
-# Install dependencies (Rust via rustup for Cargo 1.85+ / edition2024 support)
+# Install dependencies
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         cmake \
@@ -154,6 +154,7 @@ COPY --from=builder_qsym $CARGO_HOME $CARGO_HOME
 COPY --from=builder_qsym /symcc_build /symcc_build
 COPY --from=builder_qsym $CARGO_HOME/bin/symcc_fuzzing_helper /symcc_build/
 COPY util/pure_concolic_execution.sh /symcc_build/
+COPY test/test_readme_c_smoke.sh /symcc_build/
 COPY --from=builder_qsym /libcxx_symcc_install /libcxx_symcc_install
 COPY --from=builder_qsym /afl /afl
 

--- a/README.md
+++ b/README.md
@@ -183,11 +183,12 @@ The Docker image also has AFL and `symcc_fuzzing_helper` preinstalled, so you
 can use it to run SymCC with a fuzzer as described in [the
 docs](docs/Fuzzing.txt). (The AFL binaries are located in `/afl`.)
 
-To run a quick Docker smoke test that checks `sym++` and verifies one generated
-testcase contains `root`, use:
+Right after building the Docker image, you can run quick smoke tests for both
+C++ and C examples:
 
 ```
 $ ./test/test_sympp_root_in_docker.sh symcc
+$ ./test/test_readme_c_smoke.sh
 ```
 
 While the Docker image is very convenient for _using_ SymCC, I recommend a local

--- a/test/test_readme_c_smoke.sh
+++ b/test/test_readme_c_smoke.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKDIR="${1:-/tmp/symcc-readme-c-smoke}"
+ROUNDS="${2:-4}"
+
+mkdir -p "$WORKDIR/results"
+cd "$WORKDIR"
+
+cat > test.c <<'EOF'
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int foo(int a, int b) {
+  if (2 * a < b)
+    return a;
+  else if (a % b)
+    return b;
+  else
+    return a + b;
+}
+
+int main(int argc, char* argv[]) {
+  int x;
+  if (read(STDIN_FILENO, &x, sizeof(x)) != sizeof(x)) {
+    printf("Failed to read x\n");
+    return -1;
+  }
+  printf("%d\n", foo(x, 7));
+  return 0;
+}
+EOF
+
+symcc -O2 test.c -o test
+export SYMCC_OUTPUT_DIR="$WORKDIR/results"
+
+# Seed input from README.
+printf 'aaaa' > seed.bin
+./test < seed.bin >/dev/null
+
+# Symbolic smoke: run seed + generated inputs for a few rounds.
+outputs="$WORKDIR/symbolic_outputs.txt"
+: > "$outputs"
+
+for _ in $(seq 1 "$ROUNDS"); do
+  for tc in "$WORKDIR"/results/*; do
+    [ -f "$tc" ] || continue
+
+    out=$(./test < "$tc" | tr -d '\r\n')
+    printf '%s\n' "$out" >> "$outputs"
+
+    ./test < "$tc" >/dev/null
+  done
+done
+
+count_cases=$(ls -1 "$WORKDIR/results" | wc -l)
+[ "$count_cases" -ge 2 ]
+distinct_symbolic=$(sort -u "$outputs" | wc -l)
+[ "$distinct_symbolic" -ge 2 ]
+
+# Deterministic branch checks for the three foo() outcomes.
+printf '\x01\x00\x00\x00' > in_a.bin      # 2*a < 7  => return a
+printf '\x08\x00\x00\x00' > in_b.bin      # a % 7 != 0 => return b (=7)
+printf '\x07\x00\x00\x00' > in_apb.bin    # else => return a + b (=14)
+
+[ "$(./test < in_a.bin | tr -d '\r\n')" = "1" ]
+[ "$(./test < in_b.bin | tr -d '\r\n')" = "7" ]
+[ "$(./test < in_apb.bin | tr -d '\r\n')" = "14" ]
+
+echo "PASS: README C testcase smoke test passed (symbolic + all 3 branch outcomes)"


### PR DESCRIPTION
## Summary
- add `test/test_readme_c_smoke.sh` to exercise the README C example inside Docker
- run a symbolic smoke loop over generated testcases and assert multiple symbolic outputs are observed
- add deterministic checks for the three `foo(a, 7)` outcomes (`a`, `b`, and `a+b`) and copy the script into `/symcc_build` in the Docker image

## Test plan
- [x] `docker build -t symcc .`
- [x] `docker run --rm symcc bash -lc '/symcc_build/test_readme_c_smoke.sh /tmp/readme-c-smoke 4'`

Made with [Cursor](https://cursor.com)