### PR TITLE
Fix #175: declare int (not i1) runtime params to match C ABI

### DIFF
--- a/compiler/Runtime.cpp
+++ b/compiler/Runtime.cpp
@@ -45,7 +45,8 @@ Runtime::Runtime(Module &M) {
   buildInteger = import(M, "_sym_build_integer", ptrT, IRB.getInt64Ty(), int8T);
   buildInteger128 = import(M, "_sym_build_integer128", ptrT, IRB.getInt64Ty(),
                            IRB.getInt64Ty());
-  buildFloat = import(M, "_sym_build_float", ptrT, IRB.getDoubleTy(), int1T);
+  buildFloat =
+      import(M, "_sym_build_float", ptrT, IRB.getDoubleTy(), IRB.getInt32Ty());
   buildNullPointer = import(M, "_sym_build_null_pointer", ptrT);
   buildTrue = import(M, "_sym_build_true", ptrT);
   buildFalse = import(M, "_sym_build_false", ptrT);
@@ -54,10 +55,12 @@ Runtime::Runtime(Module &M) {
   buildZExt = import(M, "_sym_build_zext", ptrT, ptrT, int8T);
   buildTrunc = import(M, "_sym_build_trunc", ptrT, ptrT, int8T);
   buildBswap = import(M, "_sym_build_bswap", ptrT, ptrT);
-  buildIntToFloat =
-      import(M, "_sym_build_int_to_float", ptrT, ptrT, int1T, int1T);
-  buildFloatToFloat = import(M, "_sym_build_float_to_float", ptrT, ptrT, int1T);
-  buildBitsToFloat = import(M, "_sym_build_bits_to_float", ptrT, ptrT, int1T);
+  buildIntToFloat = import(M, "_sym_build_int_to_float", ptrT, ptrT,
+                           IRB.getInt32Ty(), IRB.getInt32Ty());
+  buildFloatToFloat =
+      import(M, "_sym_build_float_to_float", ptrT, ptrT, IRB.getInt32Ty());
+  buildBitsToFloat =
+      import(M, "_sym_build_bits_to_float", ptrT, ptrT, IRB.getInt32Ty());
   buildFloatToBits = import(M, "_sym_build_float_to_bits", ptrT, ptrT);
   buildFloatToSignedInt =
       import(M, "_sym_build_float_to_signed_integer", ptrT, ptrT, int8T);

--- a/compiler/Symbolizer.cpp
+++ b/compiler/Symbolizer.cpp
@@ -663,7 +663,7 @@ void Symbolizer::visitBitCastInst(BitCastInst &I) {
     auto conversion =
         buildRuntimeCall(IRB, runtime.buildBitsToFloat,
                          {{I.getOperand(0), true},
-                          {IRB.getInt1(I.getDestTy()->isDoubleTy()), false}});
+                          {IRB.getInt32(I.getDestTy()->isDoubleTy()), false}});
     registerSymbolicComputation(conversion, &I);
     return;
   }
@@ -722,8 +722,8 @@ void Symbolizer::visitSIToFPInst(SIToFPInst &I) {
   auto conversion =
       buildRuntimeCall(IRB, runtime.buildIntToFloat,
                        {{I.getOperand(0), true},
-                        {IRB.getInt1(I.getDestTy()->isDoubleTy()), false},
-                        {/* is_signed */ IRB.getInt1(true), false}});
+                        {IRB.getInt32(I.getDestTy()->isDoubleTy()), false},
+                        {/* is_signed */ IRB.getInt32(1), false}});
   registerSymbolicComputation(conversion, &I);
 }
 
@@ -732,8 +732,8 @@ void Symbolizer::visitUIToFPInst(UIToFPInst &I) {
   auto conversion =
       buildRuntimeCall(IRB, runtime.buildIntToFloat,
                        {{I.getOperand(0), true},
-                        {IRB.getInt1(I.getDestTy()->isDoubleTy()), false},
-                        {/* is_signed */ IRB.getInt1(false), false}});
+                        {IRB.getInt32(I.getDestTy()->isDoubleTy()), false},
+                        {/* is_signed */ IRB.getInt32(0), false}});
   registerSymbolicComputation(conversion, &I);
 }
 
@@ -742,7 +742,7 @@ void Symbolizer::visitFPExtInst(FPExtInst &I) {
   auto conversion =
       buildRuntimeCall(IRB, runtime.buildFloatToFloat,
                        {{I.getOperand(0), true},
-                        {IRB.getInt1(I.getDestTy()->isDoubleTy()), false}});
+                        {IRB.getInt32(I.getDestTy()->isDoubleTy()), false}});
   registerSymbolicComputation(conversion, &I);
 }
 
@@ -751,7 +751,7 @@ void Symbolizer::visitFPTruncInst(FPTruncInst &I) {
   auto conversion =
       buildRuntimeCall(IRB, runtime.buildFloatToFloat,
                        {{I.getOperand(0), true},
-                        {IRB.getInt1(I.getDestTy()->isDoubleTy()), false}});
+                        {IRB.getInt32(I.getDestTy()->isDoubleTy()), false}});
   registerSymbolicComputation(conversion, &I);
 }
 
@@ -978,7 +978,7 @@ Instruction *Symbolizer::createValueExpression(Value *V, IRBuilder<> &IRB) {
   if (valueType->isFloatingPointTy()) {
     return IRB.CreateCall(runtime.buildFloat,
                           {IRB.CreateFPCast(V, IRB.getDoubleTy()),
-                           IRB.getInt1(valueType->isDoubleTy())});
+                           IRB.getInt32(valueType->isDoubleTy())});
   }
 
   if (valueType->isPointerTy()) {
@@ -1135,7 +1135,7 @@ Instruction *Symbolizer::convertBitVectorExprForType(llvm::IRBuilder<> &IRB,
 
   if (T->isFloatingPointTy()) {
     result = IRB.CreateCall(runtime.buildBitsToFloat,
-                            {I, IRB.getInt1(T->isDoubleTy())});
+                            {I, IRB.getInt32(T->isDoubleTy())});
   } else if (T->isIntegerTy() && T->getIntegerBitWidth() == 1) {
     result = IRB.CreateCall(runtime.buildTrunc,
                             {I, ConstantInt::get(IRB.getInt8Ty(), 1)});


### PR DESCRIPTION
Fixes #175 (follow-up to #83).

Audited every `int1T` parameter in `compiler/Runtime.cpp` against the C signatures in `runtime/include/RuntimeCommon.h`. The functions whose C parameter is `int` were declared with `i1`, the same mismatch as #83 — the callee reads 32 bits while the compiler passes one, so the high bits can be dirty:

- `_sym_build_float` (`int is_double`)
- `_sym_build_int_to_float` (`int is_double, int is_signed`)
- `_sym_build_float_to_float` (`int to_double`)
- `_sym_build_bits_to_float` (`int to_double`)

This declares those parameters as `i32` and passes the flags as `i32` at the call sites.

The remaining `i1` parameters correspond to C `bool` arguments (`_sym_build_bool`, the overflow helpers, `_sym_read_memory` / `_sym_write_memory`, `_sym_build_insert` / `_sym_build_extract`). For `bool`, clang already lowers to `i1`, the width matches, and the callee observes only one bit, so these are not affected by the #83 mechanism and are left unchanged. `_sym_push_path_constraint` is handled in #186.

Verified behavior-preserving: a float-heavy program (float/double compares, int→float, float→float, bitcast) produces identical diverging inputs before and after, and instruments without verifier errors.